### PR TITLE
replace  "/" to "\" on expected file's path string when file.separato…

### DIFF
--- a/gaiden-core/src/test/groovy/gaiden/FunctionalSpec.groovy
+++ b/gaiden-core/src/test/groovy/gaiden/FunctionalSpec.groovy
@@ -76,6 +76,9 @@ abstract class FunctionalSpec extends GaidenSpec {
             if (PathUtils.getExtension(file) == "html") {
                 def actual = format(outputFile.text)
                 def expected = format(file.text)
+                if (System.getProperty('file.separator') == "\\") {
+                    expected = expected.replaceAll(/(href|src)="((?!http|https|\/about\/)[^"].*)"/){ it[1] + '="' + it[2].replaceAll("\\/", "\\\\") + '"' }
+                }
                 assertThat(actual, is(expected))
             }
         }


### PR DESCRIPTION
Windows でもテストが実行が成功するようにする

file.separatorが"\"のときにテスト比較用の結果ファイルにあるパスについて、"/"から"\"に書き換えてから比較する。
URL が http or https で始まっているときには変換対象としない。
="/about/" というURLがあったので、それも対象外にしているが、絶対パス指定で "/about/a.html" へのリンクがあった場合の対処はできていない。実際にはテスト対象ファイルにはそのようなURLは存在しないので、正規表現をあまり複雑にしないことを考え、問題ないのではないかと思われる。